### PR TITLE
Add selection category list on add item form

### DIFF
--- a/src/main/java/ro/vladutit/Don/t/forget/v2/controller/ItemController.java
+++ b/src/main/java/ro/vladutit/Don/t/forget/v2/controller/ItemController.java
@@ -8,6 +8,8 @@ import ro.vladutit.Don.t.forget.v2.model.Item;
 import ro.vladutit.Don.t.forget.v2.service.CategoryService;
 import ro.vladutit.Don.t.forget.v2.service.ItemService;
 
+import javax.servlet.http.HttpServletRequest;
+
 @Controller ("/item")
 public class ItemController {
     @Autowired
@@ -24,9 +26,10 @@ public class ItemController {
     }
 
     @RequestMapping("/add")
-    public String addNewItemForm(Model model) {
+    public String addNewItemForm(Model model, Model category) {
         Item item = new Item();
         model.addAttribute("item", item);
+        category.addAttribute("listCategories", categoryService.getAllCategories());
         return "add_item";
     }
 

--- a/src/main/resources/templates/add_item.html
+++ b/src/main/resources/templates/add_item.html
@@ -16,11 +16,25 @@
       <div>
         <form action="#" th:action="@{/save}" th:object="${item}" method="POST">
           <div class="mb-3">
+            <label>First of all, please select/add a category: * </label>
+            <div class="form-group">
+              <select class="form-control selectpicker" required th:field="*{category.name}">
+                <option value="">Nothing selected</option>
+                <option th:each="category : ${listCategories}"
+                        th:value="${category.name}"
+                        th:text="${category.name}">
+                </option>
+              </select>
+            </div>
+            <label>Didn't find the category you were looking for?</label>
+            <a type="button" class="btn btn-light" href="/category/add">Add new category</a>
+          </div>
+            <hr class="mb-4">
+          <div class="mb-3">
             <label for="itemBarcode">Barcode</label>
             <input type="text" th:field="*{codeBarId}" placeholder="Barcode" class="form-control"
                    id="itemBarcode" value="">
           </div>
-
           <div class="mb-3">
             <label for="itemName">Name*</label>
             <input type="text" th:field="*{name}" placeholder="Item Name" class="form-control"


### PR DESCRIPTION
I added a  **selection category list** on **add item form**. If there are no categories in the list or there is no category we want, I added a button to redirect us to the add category form, then we can return to the page to add item form. I added the _Frontend_ part, but also the _Backend_ part.
https://www.loom.com/share/f3d4ff378f83430190d2e33bcaed94f9