### PR TITLE
Add edit category form and update edit item form - Backend and Frontend

### DIFF
--- a/src/main/java/ro/vladutit/Don/t/forget/v2/controller/CategoryController.java
+++ b/src/main/java/ro/vladutit/Don/t/forget/v2/controller/CategoryController.java
@@ -3,9 +3,7 @@ package ro.vladutit.Don.t.forget.v2.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import ro.vladutit.Don.t.forget.v2.model.Category;
 import ro.vladutit.Don.t.forget.v2.service.CategoryService;
 
@@ -27,6 +25,18 @@ public class CategoryController {
     public String addnewCategory(@ModelAttribute("category") Category category) {
         categoryService.addCategory(category);
         return "redirect:/all";
+    }
+
+    // Update an category by name
+    @GetMapping("/category/{id}")
+    public String updateItemForm(@PathVariable(value = "id") String name, Model model) {
+        // Get category from the service
+        Category category = categoryService.getCateboryByName(name);
+        System.out.println("Categorie id: " + name);
+
+        // Set category as a model attribute to pre-populate the form
+        model.addAttribute("category", category);
+        return "update_category";
     }
 
 }

--- a/src/main/java/ro/vladutit/Don/t/forget/v2/controller/ItemController.java
+++ b/src/main/java/ro/vladutit/Don/t/forget/v2/controller/ItemController.java
@@ -8,8 +8,6 @@ import ro.vladutit.Don.t.forget.v2.model.Item;
 import ro.vladutit.Don.t.forget.v2.service.CategoryService;
 import ro.vladutit.Don.t.forget.v2.service.ItemService;
 
-import javax.servlet.http.HttpServletRequest;
-
 @Controller ("/item")
 public class ItemController {
     @Autowired
@@ -34,23 +32,24 @@ public class ItemController {
     }
 
     // Update an item by id
-    @RequestMapping("/edit/{id}")
-    public String updateItemForm(@PathVariable (value = "id") Long id, Model model) {
-        //get item from the service
+    @GetMapping("/edit/{id}")
+    public String updateItemForm(@PathVariable (value = "id") Long id, Model model, Model category) {
+        // Get item from the service
         Item item = itemService.getItemById(id);
 
-        //set item as a model attribute to pre-populate the form
+        // Set item as a model attribute to pre-populate the form
         model.addAttribute("item", item);
+        category.addAttribute("listCategories", categoryService.getAllCategories());
         return "update_item";
     }
 
     // Display an item by id
-    @RequestMapping("/view/{id}")
+    @GetMapping("/view/{id}")
     public String viewItemForm(@PathVariable (value = "id") Long id, Model model) {
-        //get item from the service
+        // Get item from the service
         Item item = itemService.getItemById(id);
 
-        //set item as a model attribute for view form
+        // Set item as a model attribute for view form
         model.addAttribute("item", item);
         return "view_item";
     }
@@ -58,7 +57,6 @@ public class ItemController {
     // Delete an item by id
     @RequestMapping("/delete/{id}")
     public String deleteItem(@PathVariable (value = "id") Long id) {
-        //call delete item method
         this.itemService.deleteItemById(id);
         return "redirect:/all";
     }

--- a/src/main/java/ro/vladutit/Don/t/forget/v2/controller/ItemController.java
+++ b/src/main/java/ro/vladutit/Don/t/forget/v2/controller/ItemController.java
@@ -8,6 +8,8 @@ import ro.vladutit.Don.t.forget.v2.model.Item;
 import ro.vladutit.Don.t.forget.v2.service.CategoryService;
 import ro.vladutit.Don.t.forget.v2.service.ItemService;
 
+import javax.servlet.http.HttpServletRequest;
+
 @Controller ("/item")
 public class ItemController {
     @Autowired
@@ -24,9 +26,10 @@ public class ItemController {
     }
 
     @RequestMapping("/add")
-    public String addNewItemForm(Model model) {
+    public String addNewItemForm(Model model, Model category) {
         Item item = new Item();
         model.addAttribute("item", item);
+        category.addAttribute("listCategories", categoryService.getAllCategories());
         return "add_item";
     }
 

--- a/src/main/java/ro/vladutit/Don/t/forget/v2/service/CategoryService.java
+++ b/src/main/java/ro/vladutit/Don/t/forget/v2/service/CategoryService.java
@@ -6,6 +6,7 @@ import ro.vladutit.Don.t.forget.v2.model.Category;
 import ro.vladutit.Don.t.forget.v2.repository.CategoryRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class CategoryService {
@@ -19,5 +20,16 @@ public class CategoryService {
 
     public void addCategory (Category category) {
         categoryRepository.save(category);
+    }
+
+    public Category getCateboryByName(String name) {
+        Optional<Category> optional = categoryRepository.findById(name);
+        Category category = null;
+        if(optional.isPresent()) {
+            category = optional.get();
+        } else {
+            throw new RuntimeException("Category not found for: " + name);
+        }
+        return category;
     }
 }

--- a/src/main/resources/templates/Fragments/menu.html
+++ b/src/main/resources/templates/Fragments/menu.html
@@ -88,7 +88,8 @@
                 <a class="nav-link" href="/all">All</a>
                 <a class="nav-link" href="#">Expired</a>
                 <div th:each = "category : ${listCategories}">
-                    <a class="nav-link" href="#" th:text = "${category.name}"></a>
+                    <a class="nav-link" th:href="@{/category/{id}(id=${category.name})}"
+                       th:text = "${category.name}"></a>
                 </div>
                 <div class="mt-1">
                     <a th:href = "@{/category/add}" class="btn btn-sm" title="Add new category">

--- a/src/main/resources/templates/add_item.html
+++ b/src/main/resources/templates/add_item.html
@@ -16,11 +16,25 @@
       <div>
         <form action="#" th:action="@{/save}" th:object="${item}" method="POST">
           <div class="mb-3">
+            <label>First of all, please select/add a category: * </label>
+            <div class="form-group">
+              <select class="form-control selectpicker" required th:field="*{category.name}">
+                <option value="">Nothing selected</option>
+                <option th:each="category : ${listCategories}"
+                        th:value="${category.name}"
+                        th:text="${category.name}">
+                </option>
+              </select>
+            </div>
+            <label>Didn't find the category you were looking for?</label>
+            <a type="button" class="btn btn-light" href="/category/add">Add new category</a>
+          </div>
+            <hr class="mb-4">
+          <div class="mb-3">
             <label for="itemBarcode">Barcode</label>
             <input type="text" th:field="*{codeBarId}" placeholder="Barcode" class="form-control"
                    id="itemBarcode" value="">
           </div>
-
           <div class="mb-3">
             <label for="itemName">Name*</label>
             <input type="text" th:field="*{name}" placeholder="Item Name" class="form-control"

--- a/src/main/resources/templates/update_category.html
+++ b/src/main/resources/templates/update_category.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <div th:replace="fragments/header :: header"></div>
+</head>
+<body class="bg-light">
+  <div th:replace="fragments/menu :: mainMenu"></div>
+
+  <!-- Start main container -->
+  <main>
+    <div class="py-5 container">
+      <div class=" text-center">
+        <h2>Edit an item</h2>
+      </div>
+
+      <div>
+        <form action="#" th:action="@{/category/save}" th:object="${category}" method="POST">
+          <input type="hidden" th:field="*{name}">
+          <div class="mb-3">
+            <label for="itemName">Name</label>
+            <a type="text" th:text="*{name}" placeholder="Name" class="form-control"
+               id="itemName" value=""></a>
+            <small id="itemNameBlock" class="form-text text-muted">
+              The name cannot be changed, because it is unique.
+            </small>
+          </div>
+
+          <div class="mb-3">
+            <label for="itemDescription">Description</label>
+            <input type="text" th:field="*{description}" placeholder="Description" class="form-control"
+                   id="itemDescription">
+          </div>
+
+
+          <hr class="mb-4">
+
+          <div class="row">
+            <div class="col-md-6 mb-3">
+              <button class="btn btn-outline-warning btn-lg btn-block" type="submit">Save</button>
+            </div>
+            <div class="col-md-6 mb-3">
+              <button href="#" onclick="history.go(-1)" type="button"
+                      class="btn btn-danger btn-lg btn-block">Cancel</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+  <!-- End main container -->
+
+  <div th:replace="fragments/footer :: footer"></div>
+
+</body>
+</html>

--- a/src/main/resources/templates/update_item.html
+++ b/src/main/resources/templates/update_item.html
@@ -31,7 +31,7 @@
 
           <div class="mb-3">
             <label for="itemDescription">Description</label>
-            <input type="text" th:field="*{description}" placeholder="Product Description" class="form-control"
+            <input type="text" th:field="*{description}" placeholder="Description" class="form-control"
                    id="itemDescription">
           </div>
 
@@ -39,6 +39,21 @@
             <label for="itemExpirationDate">Expiration Date</label>
             <input type="date" th:field="*{expirationDate}" placeholder="YYYY-MM-DD" class="form-control"
                    id="itemExpirationDate">
+          </div>
+
+          <div class="mb-3">
+            <label>Category </label>
+            <div class="form-group">
+              <select class="form-control selectpicker" required th:field="*{category.name}">
+                <option value="">Nothing selected</option>
+                <option th:each="category : ${listCategories}"
+                        th:value="${category.name}"
+                        th:text="${category.name}">
+                </option>
+              </select>
+            </div>
+            <label>Didn't find the category you were looking for?</label>
+            <a type="button" class="btn btn-light" href="/category/add">Add new category</a>
           </div>
 
           <hr class="mb-4">


### PR DESCRIPTION
Now if we click on one of the **categories** that appear under the main menu, it sends us to a form where we can **edit the category information**. Here I realized that in the future I have to add a _Long id_ in the _Categories table_, and the _name_ should be only _unique_, but not the _id_. Because, if we wrote the wrong name from the beginning, at the moment it is harder to change the name, if items of that category are already linked.
I also added in the **edit item form**, a **list** of existing **categories** and a _button_ to the **add a new category form**, all so that we can _change_ that item into another category.
**Minor changes:**
-in the _controller_ I changed some _RequestMappings_ to some more suitable ones;
-I reformatted the _comments_ by changing the first letter to uppercase.
https://www.loom.com/share/3fbc973fdb184770bd4737c9987961fe