### PR TITLE
Fix main menu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity5</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>

--- a/src/main/resources/templates/fragments/index_layout.html
+++ b/src/main/resources/templates/fragments/index_layout.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:layout="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:layout="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://thymeleaf.org/thymeleaf-extras-springsecurity5" >
 <head>
     <div th:replace="fragments/header :: header"></div>
-    <div th:replace="fragments/menu :: indexMenu"></div>
+    <div sec:authorize="isAnonymous()" th:replace="fragments/menu :: indexMenu"></div>
+    <div sec:authorize="isAuthenticated()" th:replace="fragments/menu :: mainMenu"></div>
 </head>
 <body class="bg-light">
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
-<html lang="en" xmlns:layout="http://www.w3.org/1999/xhtml" layout:decorate="~{fragments/index_layout}">
+<html lang="en" xmlns:layout="http://www.w3.org/1999/xhtml" layout:decorate="~{fragments/index_layout}"
+      xmlns:sec="https://thymeleaf.org/thymeleaf-extras-springsecurity5" >
 <head>
 </head>
 <body class="bg-gradient-light">
@@ -158,7 +159,7 @@
         <!-- End row nr 3 -->
 
         <!-- Login and Sign up buttons -->
-        <div class="container text-center">
+        <div class="container text-center" sec:authorize="isAnonymous()">
             <p class="lead">
                 <a href="/login" class="btn btn-lg btn-warning mr-2">Sign in</a>
                 <a href="/register" class="btn btn-lg btn-outline-warning">Sign up</a>


### PR DESCRIPTION
When we are not logged in, the home page menu contains only the links to the pages we have access to, and the login and registration buttons. When we logged in, this menu must also contain buttons to Dashboard, Profile, Notification; and the login and registration buttons must be replaced with a single button, the logout button. Including the two buttons at the bottom of the main page, login and registration should no longer exist when we are logged in.

To do this, we will use the library "_https://thymeleaf. org/thymeleaf-extras-springsecurity5_" using the tools: 

- sec: authorize = "isAnonymous ()" 
- sec: authorize = "isAuthenticated ()"